### PR TITLE
Upgrade to latest version of Jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.6.2.201302030002</version>
+          <version>0.7.0.201403182114</version>
           <executions>
             <execution>
               <id>prepare-agent</id>
@@ -119,15 +119,44 @@
                 <goal>check</goal>
               </goals>
               <configuration>
-                <!-- default check ratio : can be overriden in inherited projects -->
-                <check>
-                  <classRatio>100</classRatio>
-                  <instructionRatio>80</instructionRatio>
-                  <methodRatio>80</methodRatio>
-                  <branchRatio>80</branchRatio>
-                  <complexityRatio>80</complexityRatio>
-                  <lineRatio>80</lineRatio>
-                </check>
+		<!-- default check ratio : can be overriden in inherited projects -->
+		<rules>
+  		  <rule implementation="org.jacoco.maven.RuleConfiguration">
+    		    <element>BUNDLE</element>
+    		    <limits>
+      		      <limit implementation="org.jacoco.report.check.Limit">
+        	 	<counter>CLASS</counter>
+        		<value>COVEREDRATIO</value>
+        		<minimum>1</minimum>
+      		      </limit>
+      		      <limit implementation="org.jacoco.report.check.Limit">
+           	  	<counter>INSTRUCTION</counter>
+        		<value>COVEREDRATIO</value>
+        		<minimum>0.80</minimum>
+      		      </limit>
+                      <limit implementation="org.jacoco.report.check.Limit">
+                        <counter>METHOD</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>0.80</minimum>
+                      </limit>
+                      <limit implementation="org.jacoco.report.check.Limit">
+                        <counter>BRANCH</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>0.80</minimum>
+                      </limit>
+                      <limit implementation="org.jacoco.report.check.Limit">
+                        <counter>COMPLEXITY</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>0.80</minimum>
+                      </limit>
+                      <limit implementation="org.jacoco.report.check.Limit">
+                        <counter>LINE</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>0.80</minimum>
+                      </limit>
+    		    </limits>
+  		  </rule>
+		</rules>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
... so that AssertJ modules can be built with JDK8.
This has required to rewrite the existing rule, given their format
has changed since last time.
