### PR TITLE
Corrected the license URL for the ASF ASL 2.0 license.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>LICENSE.txt</url>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
Running the Maven License Plugin fails for assertJ with an error message since the license URL points to a local file:

```
mvn license:download-licenses
...
[INFO] --- license-maven-plugin:1.7:download-licenses (default-cli) @ clienttesting ---
[WARNING] POM for dependency org.assertj:assertj-core has an invalid license URL: LICENSE.txt  
```

With this commit the license URL points to a valid URL for the ASF AL 2.0.
